### PR TITLE
Create FastAPI interface based on PRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ pytest
 ## Test plan
 
 The file [docs/test_plan.md](docs/test_plan.md) describes the PRD-based test categories and the criteria used to verify each feature.
+
+## Running the API server
+
+This repository includes a small FastAPI application exposing the basic endpoints proposed in the PRD. To start the development server run:
+
+```bash
+uvicorn src.app:app --reload
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests
 pytest
+fastapi
+uvicorn

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,79 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from pydantic import BaseModel
+from typing import List
+
+app = FastAPI(title="Kiko API")
+
+
+class Episode(BaseModel):
+    id: int
+    title: str
+    length: int
+    script: str | None = None
+
+
+fake_episodes: List[Episode] = [
+    Episode(id=1, title="Sample Episode", length=300, script="こんにちは"),
+]
+
+
+class User(BaseModel):
+    username: str
+    password: str
+
+
+class VocabWord(BaseModel):
+    id: int
+    word: str
+    meaning: str
+
+
+fake_vocab: List[VocabWord] = []
+
+
+@app.post("/auth/signup")
+@app.post("/auth/login")
+def auth(user: User):
+    """Mock authentication returning a fake token."""
+    return {"token": "fake-token"}
+
+
+@app.get("/episodes", response_model=List[Episode])
+def list_episodes():
+    return fake_episodes
+
+
+@app.get("/episodes/{episode_id}", response_model=Episode)
+def get_episode(episode_id: int):
+    for ep in fake_episodes:
+        if ep.id == episode_id:
+            return ep
+    raise HTTPException(status_code=404, detail="Episode not found")
+
+
+@app.post("/transcribe")
+async def transcribe(file: UploadFile = File(...)):
+    """Receive an audio file and return a transcription id (mock)."""
+    # In a real implementation this would store the file and invoke the STT service.
+    return {"transcript_id": "123"}
+
+
+@app.get("/transcribe/{transcript_id}")
+def get_transcription(transcript_id: str):
+    """Return transcription result (mock)."""
+    # Placeholder: call to external STT service
+    result = {
+        "text": "dummy text"
+    }
+    return result
+
+
+@app.post("/vocab", response_model=VocabWord)
+def add_vocab(word: VocabWord):
+    fake_vocab.append(word)
+    return word
+
+
+@app.get("/vocab", response_model=List[VocabWord])
+def list_vocab():
+    return fake_vocab


### PR DESCRIPTION
## Summary
- add minimal FastAPI server with episode, vocab and auth routes
- document running the server
- include FastAPI and uvicorn dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68402b676120833284d33388b53def8a